### PR TITLE
fog: frameworks/SystemUI: statusbar adjustments

### DIFF
--- a/overlay/FogFrameworksOverlay/res/values/config.xml
+++ b/overlay/FogFrameworksOverlay/res/values/config.xml
@@ -183,7 +183,7 @@
                 <string ...>M -5,0 L -5,10 L 5,10 L 5,0 Z @dp</string>
          @see https://www.w3.org/TR/SVG/paths.html#PathData
          -->
-    <string translatable="false" name="config_mainBuiltInDisplayCutout">M 0,0 H -40 V 49 H 40 V 0 H 0 Z</string>
+    <string translatable="false" name="config_mainBuiltInDisplayCutout">M 0,0 H -64 V 60 H 64 V 0 H 0 Z</string>
 
     <!-- Whether the display cutout region of the main built-in display should be forced to
         black in software (to avoid aliasing or emulate a cutout that is not physically existent).

--- a/overlay/FogSystemUIOverlay/res/values/config.xml
+++ b/overlay/FogSystemUIOverlay/res/values/config.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-/* //device/apps/common/assets/res/any/dimens.xml
-**
-** Copyright 2006, The Android Open Source Project
+/*
+** Copyright 2015, The Android Open Source Project
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -17,16 +16,12 @@
 ** limitations under the License.
 */
 -->
-<resources>
-    <!-- Height of the status bar.
-         Do not read this dimen directly. Use {@link SystemBarUtils#getStatusBarHeight} instead.
-         -->
-    <dimen name="status_bar_height_default">60.0px</dimen>
-    <dimen name="status_bar_height_landscape">24dp</dimen>
-    <dimen name="status_bar_height_portrait">60.0px</dimen>
 
-    <!-- Default radius of the software rounded corners. -->
-    <dimen name="rounded_corner_radius">5dp</dimen>
-    <dimen name="rounded_corner_content_padding">28.0px</dimen>
-    
+<!-- These resources are around just to allow their values to be customized
+     for different hardware and product builds. -->
+<resources>
+
+    <!-- Respect drawable/rounded.xml intrinsic size for multiple radius corner path customization -->
+    <bool name="config_roundedCornerMultipleRadius">true</bool>
+
 </resources>

--- a/overlay/FogSystemUIOverlay/res/values/dimens.xml
+++ b/overlay/FogSystemUIOverlay/res/values/dimens.xml
@@ -17,7 +17,7 @@
 -->
 <resources>
     <!-- the padding on the start of the statusbar -->
-    <dimen name="status_bar_padding_start">6dp</dimen>
+    <dimen name="status_bar_padding_start">10dp</dimen>
 
     <!-- Height of the status bar header bar when on Keyguard -->
     <dimen name="status_bar_header_height_keyguard">@*android:dimen/status_bar_height_default</dimen>    


### PR DESCRIPTION
based on my old decommon tree fork for ArrowOS

- status_bar_padding_start: 10dp
- bump statusbar height to 60px
- set rounded_corner_content_padding to 28px
- add config_roundedCornerMultipleRadius property to SystemUIOverlay/res/values/config.xml